### PR TITLE
Add PvP ranking filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Generador de filtros para Pokémon GO que produce cadenas de búsqueda compatibl
 ## Uso
 
 1. Abre `index.html` en tu navegador.
-2. Selecciona las opciones de exclusión y define los valores mínimos de IV.
+2. Selecciona las opciones de exclusión, define los valores mínimos de IV y, si lo deseas, filtra por liga y top de ranking PvP.
 3. La cadena resultante se mostrará en el área de texto; pulsa **Copiar** para guardarla en el portapapeles.
 
 El sitio está pensado para ser publicado en GitHub Pages utilizando solo HTML, CSS y JavaScript.

--- a/index.html
+++ b/index.html
@@ -22,6 +22,25 @@
                 <label>Defensa: <input type="number" id="ivDef" min="0" max="15" value="0"></label>
                 <label>Stamina: <input type="number" id="ivSta" min="0" max="15" value="0"></label>
             </fieldset>
+            <fieldset>
+                <legend>Ranking PvP</legend>
+                <label>Liga:
+                    <select id="league">
+                        <option value="">--</option>
+                        <option value="great">Super</option>
+                        <option value="ultra">Ultra</option>
+                        <option value="master">Master</option>
+                    </select>
+                </label>
+                <label>Top rango:
+                    <select id="rank">
+                        <option value="0">--</option>
+                        <option value="1">1</option>
+                        <option value="5">5</option>
+                        <option value="10">10</option>
+                    </select>
+                </label>
+            </fieldset>
         </form>
         <section class="output">
             <textarea id="searchString" readonly rows="3"></textarea>

--- a/public/pvpivs.json
+++ b/public/pvpivs.json
@@ -1,0 +1,16 @@
+{
+  "great": [
+    {"name": "Azumarill", "rank": 1},
+    {"name": "Galarian Stunfisk", "rank": 2},
+    {"name": "Altaria", "rank": 3}
+  ],
+  "ultra": [
+    {"name": "Registeel", "rank": 1},
+    {"name": "Cresselia", "rank": 2},
+    {"name": "Swampert", "rank": 3}
+  ],
+  "master": [
+    {"name": "Dialga", "rank": 1},
+    {"name": "Mewtwo", "rank": 2}
+  ]
+}

--- a/script.js
+++ b/script.js
@@ -6,6 +6,17 @@ const ivDef = document.getElementById('ivDef');
 const ivSta = document.getElementById('ivSta');
 const output = document.getElementById('searchString');
 const copyButton = document.getElementById('copyButton');
+const leagueSelect = document.getElementById('league');
+const rankSelect = document.getElementById('rank');
+
+let pvpData = null;
+
+fetch('public/pvpivs.json')
+    .then(response => response.json())
+    .then(data => {
+        pvpData = data;
+        updateSearch();
+    });
 
 function updateSearch() {
     const parts = [];
@@ -23,6 +34,17 @@ function updateSearch() {
         parts.push(`iv_sta>=${ivSta.value}`);
     }
 
+    if (pvpData && leagueSelect.value && parseInt(rankSelect.value, 10) > 0) {
+        const league = leagueSelect.value;
+        const rankLimit = parseInt(rankSelect.value, 10);
+        const names = pvpData[league]
+            .filter(p => p.rank <= rankLimit)
+            .map(p => p.name);
+        if (names.length > 0) {
+            parts.push(names.join(','));
+        }
+    }
+
     output.value = parts.join(' & ');
 }
 
@@ -37,8 +59,9 @@ ivAtk.addEventListener('input', updateSearch);
 ivDef.addEventListener('input', updateSearch);
 ivSta.addEventListener('input', updateSearch);
 copyButton.addEventListener('click', copyToClipboard);
+leagueSelect.addEventListener('change', updateSearch);
+rankSelect.addEventListener('change', updateSearch);
 
 // Actualizar inicialmente
 updateSearch();
 
-// TODO: Integrar datos de pvpivs.com para filtrar por ranking


### PR DESCRIPTION
## Summary
- add sample `pvpivs.json` dataset
- include league and rank selectors in the UI
- fetch PvP rankings and filter search results
- document ranking support in the README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685134f49a3c83318888bc79f580a090